### PR TITLE
Add username and repository fields

### DIFF
--- a/src/crypto/helpers.rs
+++ b/src/crypto/helpers.rs
@@ -4,6 +4,7 @@ use home::home_dir;
 use openssl::rsa::{Padding, Rsa};
 use serde_json::value::Value;
 use std::fs;
+use std::fs::File;
 
 pub fn encrypt(data: &str) -> Result<Vec<u8>, std::io::Error> {
     let path = if let Some(home_path) = home_dir() {
@@ -11,7 +12,7 @@ pub fn encrypt(data: &str) -> Result<Vec<u8>, std::io::Error> {
     } else {
         String::from("/.rustyvault/")
     };
-    let public = fs::read_to_string(format!("{}", path))?;
+    let public = fs::read_to_string(format!("{}rustykey.pem", path))?;
 
     // Encrypt with public key
     let rsa = Rsa::public_key_from_pem(public.as_bytes()).unwrap();
@@ -28,7 +29,7 @@ pub fn decrypt(buffer: Vec<u8>) -> Result<String, std::io::Error> {
     } else {
         String::from("/.rustyvault/")
     };
-    let private = fs::read_to_string(format!("{}", path))?;
+    let private = fs::read_to_string(format!("{}rustykey", path))?;
     let passphrase = "";
     let data = buffer;
 
@@ -80,4 +81,28 @@ pub fn split_data<'a>(data: String) -> Vec<String> {
     }
 
     chunks
+}
+
+pub fn get_username() -> String {
+    let path = if let Some(home_path) = home_dir() {
+        String::from(format!("{}/.rustyvault/", home_path.to_string_lossy()))
+    } else {
+        String::from("/.rustyvault/")
+    };
+    let file = File::open(format!("{}config.json", path)).unwrap();
+    let json: serde_json::Value = serde_json::from_reader(file).expect("file should be proper JSON");
+    let username = json.get("username").expect("file should have username key");
+    return username.to_string();
+}
+
+pub fn get_repository() -> String {
+    let path = if let Some(home_path) = home_dir() {
+        String::from(format!("{}/.rustyvault/", home_path.to_string_lossy()))
+    } else {
+        String::from("/.rustyvault/")
+    };
+    let file = File::open(format!("{}config.json", path)).unwrap();
+    let json: serde_json::Value = serde_json::from_reader(file).expect("file should be proper JSON");
+    let repository = json.get("repository").expect("file should have repository key");
+    return repository.to_string();
 }

--- a/src/crypto/helpers.rs
+++ b/src/crypto/helpers.rs
@@ -6,7 +6,12 @@ use serde_json::value::Value;
 use std::fs;
 
 pub fn encrypt(data: &str) -> Result<Vec<u8>, std::io::Error> {
-    let public = fs::read_to_string("/home/andrea/.rustyvault/rustykey.pem")?;
+    let path = if let Some(home_path) = home_dir() {
+        String::from(format!("{}/.rustyvault/", home_path.to_string_lossy()))
+    } else {
+        String::from("/.rustyvault/")
+    };
+    let public = fs::read_to_string(format!("{}", path))?;
 
     // Encrypt with public key
     let rsa = Rsa::public_key_from_pem(public.as_bytes()).unwrap();
@@ -18,7 +23,12 @@ pub fn encrypt(data: &str) -> Result<Vec<u8>, std::io::Error> {
 }
 
 pub fn decrypt(buffer: Vec<u8>) -> Result<String, std::io::Error> {
-    let private = fs::read_to_string("/home/andrea/.rustyvault/rustykey")?;
+    let path = if let Some(home_path) = home_dir() {
+        String::from(format!("{}/.rustyvault/", home_path.to_string_lossy()))
+    } else {
+        String::from("/.rustyvault/")
+    };
+    let private = fs::read_to_string(format!("{}", path))?;
     let passphrase = "";
     let data = buffer;
 

--- a/src/crypto/init.rs
+++ b/src/crypto/init.rs
@@ -61,8 +61,8 @@ fn get_init_data() -> Result<(String, String, String), std::io::Error> {
     let github_api_key_confirm =
         rpassword::prompt_password_stdout("Enter again your github api key: ").unwrap();
     if pass == pass_confirm && github_api_key == github_api_key_confirm {
-        println!("Creating the key pair in the folder ~/.rustyvautl");
-        println!("Creating the file github with your api key in the folder ~/.rustyvautl");
+        println!("Creating the key pair in the folder ~/.rustyvault");
+        println!("Creating the file github with your api key in the folder ~/.rustyvault");
         return Ok((path, pass, github_api_key));
     }
     panic!("There was an error")

--- a/src/crypto/init.rs
+++ b/src/crypto/init.rs
@@ -2,12 +2,20 @@ use crate::add_to_file;
 use home::home_dir;
 use openssl::rsa::Rsa;
 use openssl::symm::Cipher;
+use serde::{Deserialize, Serialize};
+use serde_json;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
+#[derive(Serialize, Deserialize)]
+struct Config {
+    username: String,
+    repository: String,
+}
+
 pub async fn init_data() -> Result<(), std::io::Error> {
-    let (path, passphrase, github) = get_init_data()?;
+    let (path, passphrase, github, username, repository) = get_init_data()?;
     // create folder if doesnt exists
     if !Path::new(path.trim()).exists() {
         std::fs::create_dir(path.trim())?;
@@ -22,15 +30,22 @@ pub async fn init_data() -> Result<(), std::io::Error> {
     let mut private_key_file = File::create(format!("{}rustykey", path))?;
     let mut public_key_file = File::create(format!("{}rustykey.pem", path))?;
     let mut github_api = File::create(format!("{}github", path))?;
+    let mut user_config = File::create(format!("{}config.json", path))?;
 
     private_key_file.write_all(private_key_save.as_bytes())?;
     public_key_file.write_all(public_key_save.as_bytes())?;
     github_api.write_all(github.as_bytes())?;
+    let config = Config {
+        username: username,
+        repository: repository,
+    };
+    let config_json = serde_json::to_string(&config)?;
+    user_config.write_all(config_json.as_bytes())?;
 
     Ok(add_to_file(true, "default", "welcome").await?)
 }
 
-fn get_init_data() -> Result<(String, String, String), std::io::Error> {
+fn get_init_data() -> Result<(String, String, String, String, String), std::io::Error> {
     let path = if let Some(home_path) = home_dir() {
         String::from(format!("{}/.rustyvault/", home_path.to_string_lossy()))
     } else {
@@ -59,11 +74,17 @@ fn get_init_data() -> Result<(String, String, String), std::io::Error> {
     .unwrap();
     let github_api_key = rpassword::prompt_password_stdout("Enter your github api key: ").unwrap();
     let github_api_key_confirm =
-        rpassword::prompt_password_stdout("Enter again your github api key: ").unwrap();
+    rpassword::prompt_password_stdout("Enter again your github api key: ").unwrap();
+    let username = rpassword::prompt_password_stdout(
+        "Enter your GitHub username: "
+    ).unwrap();
+    let repository = rpassword::prompt_password_stdout(
+        "Enter the repository name you want to use as your vault: "
+    ).unwrap();
     if pass == pass_confirm && github_api_key == github_api_key_confirm {
         println!("Creating the key pair in the folder ~/.rustyvault");
         println!("Creating the file github with your api key in the folder ~/.rustyvault");
-        return Ok((path, pass, github_api_key));
+        return Ok((path, pass, github_api_key, username, repository));
     }
     panic!("There was an error")
 }

--- a/src/operations/adders.rs
+++ b/src/operations/adders.rs
@@ -2,6 +2,8 @@
 use super::getters::get_data;
 use crate::crypto::helpers::encrypt;
 use crate::crypto::helpers::get_api_key_value;
+use crate::crypto::helpers::get_username;
+use crate::crypto::helpers::get_repository;
 use crate::crypto::helpers::split_data;
 use base64::encode;
 use reqwest;
@@ -15,6 +17,8 @@ pub async fn add_to_file(
     password: &str,
 ) -> Result<(), std::io::Error> {
     let api_key = get_api_key_value();
+    let username = get_username();
+    let repository = get_repository();
     let mut sha = "".to_string();
     let mut filename = "default".to_string();
     let mut json_file: Value = serde_json::from_str("{}").unwrap();
@@ -27,9 +31,12 @@ pub async fn add_to_file(
     }
 
     let url = format!(
-        "https://api.github.com/repos/andcri/vault/contents/{}",
+        "https://api.github.com/repos/{}/{}/contents/{}",
+        username.replace('"', ""),
+        repository.replace('"', ""),
         filename
     );
+
     // convert the string into a json object
     // apply add the new data inside it
     json_file[id] = Value::String(String::from(password));

--- a/src/operations/getters.rs
+++ b/src/operations/getters.rs
@@ -5,6 +5,8 @@ extern crate reqwest;
 use crate::crypto::helpers::decrypt;
 use crate::crypto::helpers::extract_string_from_json;
 use crate::crypto::helpers::get_api_key_value;
+use crate::crypto::helpers::get_username;
+use crate::crypto::helpers::get_repository;
 use base64::decode;
 use copypasta_ext::prelude::*;
 use copypasta_ext::x11_fork::ClipboardContext;
@@ -12,9 +14,16 @@ use serde_json::value::Value;
 
 pub async fn get_data() -> Result<(String, String, String), std::io::Error> {
     let api_key = get_api_key_value();
+    let username = get_username();
+    let repository = get_repository();
     let client = reqwest::Client::new();
+    let endpoint = format!(
+        "https://api.github.com/repos/{}/{}/contents/default",
+        username.replace('"', ""),
+        repository.replace('"', "")
+    );
     let body = client
-        .get("https://api.github.com/repos/andcri/vault/contents/default")
+        .get(&endpoint)
         .header("Authorization", format!("token {}", api_key))
         .header("Accept", "application/vnd.github.v3+json")
         .header("User-Agent", "request")
@@ -68,7 +77,7 @@ pub async fn get_password(args: &str, show: bool) -> Result<(), std::io::Error> 
         println!("Your password for {} is {}", args.to_string(), value);
     }
     println!(
-        "Your password for {} is now copyed on your clipboard",
+        "Your password for {} is now copied on your clipboard",
         args.to_string()
     );
     Ok(())


### PR DESCRIPTION
This PR adds two extra prompts (since those fields were hardcoded):
- username
- repository

**Note**:
Just realized you already merged a similar functionality. I don't know if you implemented it the same way, but in my case during initialization the program creates a **config.json** file in `~/.rustyvault` that holds the GitHub username and repository so the user don't have to enter them again.