### PR TITLE
feat: create repo automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1380,6 +1381,16 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand 0.7.3",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ clap = "2.33.3"
 copypasta-ext = "0.3.2"
 home = "0.5.3"
 diceware-gen = "0.2.2"
+uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ $ rustyvault get <identifier>
 
 ### Options
 
-| Option | Description                     |
-| ------ | ------------------------------- |
-| -s     | Print password in your terminal |
+| Option | Use with | Description                     |
+| ------ | -------- | ------------------------------- |
+| -s     | get      | Print password in your terminal |
+| -a     | new      | Auto generate password          |
 
 Enjoy!
 

--- a/src/crypto/init.rs
+++ b/src/crypto/init.rs
@@ -2,25 +2,34 @@ use crate::add_to_file;
 use home::home_dir;
 use openssl::rsa::Rsa;
 use openssl::symm::Cipher;
+use reqwest;
 use serde::{Deserialize, Serialize};
 use serde_json;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize)]
 struct Config {
     username: String,
-    repository: String,
+    repository_name: String,
     github_api_token: String,
     password_protected: bool,
 }
 
 pub async fn init_data() -> Result<(), std::io::Error> {
-    let (path, rsa_password, username, repository, github_api_token, password_protected) = get_init_data()?;
-    println!("Creating the key pair in {}", path);
+    let (path,
+        rsa_password,
+        username,
+        mut repository_name,
+        github_api_token,
+        password_protected) = get_init_data()?;
+
     // create folder if doesnt exists
     if !Path::new(path.trim()).exists() {
+        println!("Creating the key pair in {}", path);
         std::fs::create_dir(path.trim())?;
     }
     let rsa = Rsa::generate(4096).unwrap();
@@ -33,19 +42,43 @@ pub async fn init_data() -> Result<(), std::io::Error> {
     let mut private_key_file = File::create(format!("{}rustykey", path))?;
     let mut public_key_file = File::create(format!("{}rustykey.pem", path))?;
     let mut user_config = File::create(format!("{}config.json", path))?;
-    println!("Creating your configuration file in {}", path);
 
+    // create a GitHub repository if user does not provide an existing one
+    if repository_name.len() == 0 {
+        repository_name = Uuid::new_v4().to_string();
+        println!("Creating vault repository {}", repository_name);
+        let mut json_to_post = HashMap::new();
+        json_to_post.insert("description", "Password vault");
+        json_to_post.insert("private", "true");
+        json_to_post.insert("name", &repository_name);
+        
+        let client = reqwest::Client::new();
+        client
+        .post("https://api.github.com/user/repos")
+        .header("Authorization", format!("token {}", github_api_token))
+        .header("Accept", "application/vnd.github.v3+json")
+        .header("User-Agent", "request")
+        .json(&json_to_post)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    }
+        
+    println!("Creating your configuration file in {}", path);
     private_key_file.write_all(private_key_save.as_bytes())?;
     public_key_file.write_all(public_key_save.as_bytes())?;
     let config = Config {
         username,
-        repository,
+        repository_name,
         github_api_token,
         password_protected,
     };
     let config_json = serde_json::to_string(&config)?;
     user_config.write_all(config_json.as_bytes())?;
-
+    
     Ok(add_to_file(true, "default", "welcome").await?)
 }
 
@@ -76,22 +109,23 @@ fn get_init_data() -> Result<(String, String, String, String, String, bool), std
         "Enter again the password (leave blank for no password): ",
     )
     .unwrap();
-    let github_api_key = rpassword::prompt_password_stdout("Enter your GitHub API token: ").unwrap();
-    let github_api_key_confirm =
+    let github_api_token = rpassword::prompt_password_stdout("Enter your GitHub API token: ").unwrap();
+    let github_api_token_confirm =
         rpassword::prompt_password_stdout("Enter again your GitHub API token: ").unwrap();
     let username = rpassword::prompt_password_stdout("Enter your GitHub username: ").unwrap();
-    let repository = rpassword::prompt_password_stdout(
-        "Enter the repository name you want to use as your vault: ",
+    let repository_name = rpassword::prompt_password_stdout(
+        "Enter the repository name you want to use as your vault (leave blank for automatic creation): ",
     )
     .unwrap();
-    if rsa_password == rsa_password_confirm && github_api_key == github_api_key_confirm {
+
+    if rsa_password == rsa_password_confirm && github_api_token == github_api_token_confirm {
         let password_protected = if rsa_password.len() != 0 { true } else { false };
         return Ok((
             path,
             rsa_password,
             username,
-            repository,
-            github_api_key,
+            repository_name,
+            github_api_token,
             password_protected,
         ));
     }

--- a/src/operations/adders.rs
+++ b/src/operations/adders.rs
@@ -10,9 +10,9 @@ use serde_json::value::Value;
 use std::collections::HashMap;
 
 pub async fn add_to_file(first: bool, id: &str, password: &str) -> Result<(), std::io::Error> {
-    let api_token = get_config("github_api_token");
+    let github_api_token = get_config("github_api_token");
     let username = get_config("username");
-    let repository = get_config("repository");
+    let repository_name = get_config("repository_name");
     let mut sha = "".to_string();
     let mut filename = "default".to_string();
     let mut json_file: Value = serde_json::from_str("{}").unwrap();
@@ -27,7 +27,7 @@ pub async fn add_to_file(first: bool, id: &str, password: &str) -> Result<(), st
     let url = format!(
         "https://api.github.com/repos/{}/{}/contents/{}",
         username.replace('"', ""),
-        repository.replace('"', ""),
+        repository_name.replace('"', ""),
         filename
     );
 
@@ -50,7 +50,7 @@ pub async fn add_to_file(first: bool, id: &str, password: &str) -> Result<(), st
     let client = reqwest::Client::new();
     client
         .put(url.trim())
-        .header("Authorization", format!("token {}", api_token.replace('"', "")))
+        .header("Authorization", format!("token {}", github_api_token.replace('"', "")))
         .header("Accept", "application/vnd.github.v3+json")
         .header("User-Agent", "request")
         .json(&json_to_post)

--- a/src/operations/getters.rs
+++ b/src/operations/getters.rs
@@ -11,18 +11,18 @@ use copypasta_ext::x11_fork::ClipboardContext;
 use serde_json::value::Value;
 
 pub async fn get_data() -> Result<(String, String, String), std::io::Error> {
-    let api_key = get_config("github_api_token");
+    let github_api_token = get_config("github_api_token");
     let username = get_config("username");
-    let repository = get_config("repository");
+    let repository_name = get_config("repository_name");
     let client = reqwest::Client::new();
     let endpoint = format!(
         "https://api.github.com/repos/{}/{}/contents/default",
         username.replace('"', ""),
-        repository.replace('"', "")
+        repository_name.replace('"', "")
     );
     let body = client
         .get(&endpoint)
-        .header("Authorization", format!("token {}", api_key.replace('"', "")))
+        .header("Authorization", format!("token {}", github_api_token.replace('"', "")))
         .header("Accept", "application/vnd.github.v3+json")
         .header("User-Agent", "request")
         .send()


### PR DESCRIPTION
This PR adds the following:
- Check whether the provided vault is empty
- If it is empty then call GitHub's API to create a vault repository automatically